### PR TITLE
Name based indexing into Graph with getindex

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -1231,13 +1231,16 @@ Throws a `NodeNameNotFound` exception if there is no such tensor.
 end
 
 Base.getindex(graph::Graph, name) = get_tensor_by_name(graph, name)
-Base.getindex(sess::Session, name) = sess.graph[name]
-
-Base.keys(graph::Graph) = get_operations(graph)
-Base.keys(sess::Session) = keys(sess.graph)
-
+Base.values(graph::Graph) = get_operations(graph)
+Base.keys(graph::Graph) = (node_name(op) for op in values(graph))
 Base.haskey(graph::Graph, name) = isnull(get_node_by_name(graph, name))
+
+# delegate these operations on the Graph for the session that holds it.
+Base.values(sess::Session) = values(sess.graph)
+Base.keys(sess::Session) = keys(sess.graph)
+Base.getindex(sess::Session, name) = sess.graph[name]
 Base.haskey(sess::Session, name) = haskey(graph, name)
+
 
 
 function gradients(y, x::AbstractArray)

--- a/src/core.jl
+++ b/src/core.jl
@@ -1230,6 +1230,16 @@ Throws a `NodeNameNotFound` exception if there is no such tensor.
     return Tensor(node, port)
 end
 
+Base.getindex(graph::Graph, name) = get_tensor_by_name(graph, name)
+Base.getindex(sess::Session, name) = sess.graph[name]
+
+Base.keys(graph::Graph) = get_operations(graph)
+Base.keys(sess::Session) = keys(sess.graph)
+
+Base.haskey(graph::Graph, name) = isnull(get_node_by_name(graph, name))
+Base.haskey(sess::Session, name) = haskey(graph, name)
+
+
 function gradients(y, x::AbstractArray)
     x_names = [node_name(node) for node in x]
     y_name = node_name(y)

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -127,3 +127,4 @@ macro tf(ex)
         end
     end |> esc
 end
+=#

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -127,4 +127,4 @@ macro tf(ex)
         end
     end |> esc
 end
-=#
+

--- a/src/ops/math.jl
+++ b/src/ops/math.jl
@@ -65,7 +65,7 @@ A `Tensor` of type `Int64`.
     Tensor(Operation(desc), 1)
 end
 
-Base.indmax(n::AbstractTensor, dim) = argmax(n, dim-1)
+@op Base.indmax(n::AbstractTensor, dim; name=nothing) = argmax(n, dim-1; name=name)
 
 @op function Base.max(x::AbstractTensor, y, name=nothing)
     local desc

--- a/test/core.jl
+++ b/test/core.jl
@@ -58,41 +58,40 @@ end
 @testset "Graph Node Access By Name" begin
     srand(2)
     s = Session(Graph())
-    
-	fixed_bias = rand(10)
+
+    fixed_bias = rand(10)
     @tf begin
-		X = placeholder(Float64; shape=[-1, 50])
+        X = placeholder(Float64; shape=[-1, 50])
         W = get_variable([50, 10], Float64)
-		B = constant(fixed_bias)
+        B = constant(fixed_bias)
         Y_pred_onehot = nn.softmax(X * W + B)
     end
-	run(s, global_variables_initializer())
-	
-	#Every name should show up in the session
-	@test Set(["X", "W", "B", "Y_pred_onehot"]) ⊆ Set(keys(s)) 
-	@test length(collect(values(s))) > 5
+    run(s, global_variables_initializer())
+    
+    #Every name should show up in the session
+    @test Set(["X", "W", "B", "Y_pred_onehot"]) ⊆ Set(keys(s))
+    @test length(collect(values(s))) > 5
 
-	# Should get back constant
-	@test fixed_bias == run(s, s["B"])
-	
-	# Should get back output
-	x_val = rand(100, 50)
-	pred_oh = run(s, s["Y_pred_onehot"], Dict(s["X"] => x_val))
-	@test size(pred_oh) == (100, 10)
-	
-	# Should be able to use output for math still
-	pred = run(s, indmax(s["Y_pred_onehot"], 2), Dict(s["X"] => x_val))
-	@test length(pred) == 100
+    # Should get back constant
+    @test fixed_bias == run(s, s["B"])
+    
+    # Should get back output
+    x_val = rand(100, 50)
+    pred_oh = run(s, s["Y_pred_onehot"], Dict(s["X"] => x_val))
+    @test size(pred_oh) == (100, 10)
+    
+    # Should be able to use output for math still
+    pred = run(s, indmax(s["Y_pred_onehot"], 2), Dict(s["X"] => x_val))
+    @test length(pred) == 100
 end
 
 @testset "Disconnected gradients" begin
-	let
-		as_default(Graph()) do
-			unused = get_variable("unused", [], Float64)
-			used = get_variable("used", [], Float64)
-			loss = used.^2
-			optimizer = train.minimize(train.AdamOptimizer(), loss)
-			# This would have thrown an error if Disconnected gradients were causing issues
-		end
-	end
+    let as_default(Graph()) do
+        unused = get_variable("unused", [], Float64)
+        used = get_variable("used", [], Float64)
+        loss = used.^2
+        optimizer = train.minimize(train.AdamOptimizer(), loss)
+        # This would have thrown an error if Disconnected gradients were causing issues
+        end
+    end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,59 +1,75 @@
 using Base.Test
 using TensorFlow
 
-#################
-# Graph importing
-#################
 
-if tf_version() >= v"1.0.0-rc1"
-    graph_pb = read(joinpath(dirname(@__FILE__), "graph.pb"))
-    graph = Graph()
-    sess = Session(graph)
-    x_new = constant(Int32(5))
-    options = GraphImportOptions()
-    options.input_mapping[("x", 1)] = x_new
-    push!(options.return_output, ("z", 1))
-    z = import_graph_def(graph, graph_pb, options)
-    @test run(sess, z) == [Int32(7)]
-end
-
-#################
-# get_operations
-#################
-let
-    graph = Graph()
-    TensorFlow.set_def_graph(graph)
-    x = placeholder(Int32, name="x")
-    y = placeholder(Int32, name="y")
-    z = TensorFlow.add(x, y, name="z")
-    names = Set{String}()
-    for op in get_operations(graph)
-        push!(names, get_def(op).name)
-    end
-    @test length(names) == 3
-    for name in ["x", "y", "z"]
-        @test name ∈ names
+@testset "Graph importing" begin
+    if tf_version() >= v"1.0.0-rc1"
+        graph_pb = read(joinpath(dirname(@__FILE__), "graph.pb"))
+        graph = Graph()
+        sess = Session(graph)
+        x_new = constant(Int32(5))
+        options = GraphImportOptions()
+        options.input_mapping[("x", 1)] = x_new
+        push!(options.return_output, ("z", 1))
+        z = import_graph_def(graph, graph_pb, options)
+        @test run(sess, z) == [Int32(7)]
     end
 end
 
-let
-    graph = Graph()
-    local x
-    as_default(graph) do
+@testset "get_operations" begin
+    let
+        graph = Graph()
+        TensorFlow.set_def_graph(graph)
         x = placeholder(Int32, name="x")
+        y = placeholder(Int32, name="y")
+        z = TensorFlow.add(x, y, name="z")
+        names = Set{String}()
+        for op in get_operations(graph)
+            push!(names, get_def(op).name)
+        end
+        @test length(names) == 3
+        for name in ["x", "y", "z"]
+            @test name ∈ names
+        end
     end
-    x_retrieved = get_tensor_by_name(graph, "x:0")
-    @test x == x_retrieved
+
+    let
+        graph = Graph()
+        local x
+        as_default(graph) do
+            x = placeholder(Int32, name="x")
+        end
+        x_retrieved = get_tensor_by_name(graph, "x:0")
+        @test x == x_retrieved
+    end
+
+    let
+        graph = Graph()
+        sess = Session(graph)
+        local x
+        with_device("cpu:1") do
+            x = constant(1)
+        end
+        @test run(sess, x) == 1
+    end
 end
 
-let
-    graph = Graph()
-    sess = Session(graph)
-    local x
-    with_device("cpu:1") do
-        x = constant(1)
+
+@testset "Index" begin
+    srand(2)
+    sess = Session(Graph())
+    local X, W, B, Y
+    @tf begin
+        X = constant(rand(50);)
+        W = get_variable([50, 10], Float64)
+        B = get_variable([10], Float64)
+        Y = nn.softmax(X * W + B)
     end
-    @test run(sess, x) == 1
+    @test sess["X"] == X
+    @test sess["W"] == Tensor(W.var_node)
+    @test sess["B"] == Tensor(B.var_node)
+    @test sess["Y"] == Y
+    
 end
 
 ## Disconnected gradients

--- a/test/core.jl
+++ b/test/core.jl
@@ -68,8 +68,9 @@ end
     end
 	run(s, global_variables_initializer())
 	
-	#Every name should show up in the keys of the session
-	@test  length(collect(keys(s))) >= 4
+	#Every name should show up in the session
+	@test Set(["X", "W", "B", "Y_pred_onehot"]) ⊆ Set(keys(s)) 
+	@test length(collect(values(s))) > 5
 
 	# Should get back constant
 	@test fixed_bias == run(s, s["B"])

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -30,6 +30,7 @@ using TensorFlow
 
         @test i == get_tensor_by_name(g, "i")
         @test j == get_tensor_by_name(g, "j")
+        dump(get_tensor_by_name(g, "k"))
         @test Tensor(k.var_node) == get_tensor_by_name(g, "k")
         @test Tensor(k.assign_node) == get_tensor_by_name(g, "k/Assign")
         @test ijk == get_tensor_by_name(g, "ijk")


### PR DESCRIPTION
Because I am having a bad git day. 
I am making a PR against my own PR.
This PR should be merged into #174
before #174 is merged.

What this code does is allow you to index into a graph (or into a session),
using the name of a Node.
And do all the things.
See:  `@testset "Graph Node Access By Name"`

This means that only the Graph/session object needs to be passed to a function, in order to interact with the Graph/Session.